### PR TITLE
Add bidirectional CPED approximation

### DIFF
--- a/src/repmetric/api.py
+++ b/src/repmetric/api.py
@@ -11,21 +11,41 @@ from .backend import (
     _calculate_cped_cpp,
     _calculate_cped_distance_matrix_cpp,
     _calculate_cped_distance_matrix_py,
+    _calculate_cped_distance_matrix_py_bidirectional,
     _calculate_cped_py,
+    _calculate_cped_py_bidirectional,
     _calculate_levd_cpp,
     _calculate_levd_distance_matrix_cpp,
     _calculate_levd_distance_matrix_py,
     _calculate_levd_py,
 )
 
-Backend = Literal["cpp", "c++", "python"]
+Backend = Literal[
+    "cpp",
+    "c++",
+    "python",
+    "python-bidir",
+    "python_bidirectional",
+    "bidirectional",
+    "cpp-bidir",
+    "cpp_bidirectional",
+]
 DistanceType = Literal["cped", "levd"]
 
 
 def cped(X: str, Y: str, backend: Backend = "cpp") -> int:
     """Calculate the Copy & Paste Edit Distance (CPED)."""
-    use_cpp = backend in ("cpp", "c++") and CPP_AVAILABLE
-    if use_cpp:
+
+    backend_lower = backend.lower()
+    if backend_lower in (
+        "python-bidir",
+        "python_bidirectional",
+        "bidirectional",
+        "cpp-bidir",
+        "cpp_bidirectional",
+    ):
+        return _calculate_cped_py_bidirectional(X, Y)
+    if backend_lower in ("cpp", "c++") and CPP_AVAILABLE:
         return _calculate_cped_cpp(X, Y)
     return _calculate_cped_py(X, Y)
 
@@ -34,8 +54,17 @@ def cped_matrix(
     sequences: List[str], backend: Backend = "cpp", parallel: bool = True
 ) -> np.ndarray:
     """Calculate the pairwise CPED matrix."""
-    use_cpp = backend in ("cpp", "c++") and CPP_AVAILABLE
-    if use_cpp:
+
+    backend_lower = backend.lower()
+    if backend_lower in (
+        "python-bidir",
+        "python_bidirectional",
+        "bidirectional",
+        "cpp-bidir",
+        "cpp_bidirectional",
+    ):
+        return _calculate_cped_distance_matrix_py_bidirectional(sequences)
+    if backend_lower in ("cpp", "c++") and CPP_AVAILABLE:
         return _calculate_cped_distance_matrix_cpp(sequences, parallel=parallel)
     return _calculate_cped_distance_matrix_py(sequences)
 
@@ -93,7 +122,8 @@ def edit_distance(
         a: The first string or a list of strings.
         b: The second string. If 'a' is a list, this should be None.
         distance_type: The type of distance to calculate ('cped' or 'levd').
-        backend: The backend to use for calculation ('cpp' or 'python').
+        backend: The backend to use for calculation ('cpp', 'python', or
+            'python-bidir').
         parallel: Whether to use parallel computation for the distance matrix.
 
     Returns:

--- a/tests/test_repmetric.py
+++ b/tests/test_repmetric.py
@@ -34,12 +34,12 @@ LEVD_TEST_CASES = [
 
 
 @pytest.mark.parametrize("X, Y, expected", CPED_TEST_CASES)
-@pytest.mark.parametrize("backend", ["python", "cpp", "c++"])
+@pytest.mark.parametrize("backend", ["python", "python-bidir", "cpp", "c++"])
 def test_cped_correctness(X, Y, expected, backend):
     assert repmetric.cped(X, Y, backend=backend) == expected
 
 
-@pytest.mark.parametrize("backend", ["python", "cpp", "c++"])
+@pytest.mark.parametrize("backend", ["python", "python-bidir", "cpp", "c++"])
 def test_cped_matrix_correctness(backend):
     sequences = ["a", "ab", "abc"]
     expected_matrix = np.array([[0, 1, 1], [1, 0, 1], [2, 1, 0]])
@@ -47,6 +47,13 @@ def test_cped_matrix_correctness(backend):
     # Corrected expected matrix based on re-evaluating cped logic
     expected_matrix = np.array([[0, 1, 2], [1, 0, 1], [1, 1, 0]])
     np.testing.assert_array_equal(dist_matrix, expected_matrix)
+
+
+def test_cped_bidirectional_improvement():
+    baseline = repmetric.cped("", "aaaba", backend="python")
+    improved = repmetric.cped("", "aaaba", backend="python-bidir")
+    assert baseline >= improved
+    assert improved == 4
 
 
 # --- Levenshtein Backend Correctness Tests ---
@@ -119,6 +126,12 @@ def test_edit_distance_matrix():
     )
     np.testing.assert_array_equal(
         repmetric.edit_distance(sequences, distance_type="cped", backend="python"),
+        expected_cped,
+    )
+    np.testing.assert_array_equal(
+        repmetric.edit_distance(
+            sequences, distance_type="cped", backend="python-bidir"
+        ),
         expected_cped,
     )
 


### PR DESCRIPTION
## Summary
- add a reusable CPED DP table helper and a bidirectional refinement to reduce order-dependence
- expose a `python-bidir` backend for CPED and distance matrix APIs, keeping existing names intact
- expand the test suite to cover the new backend and verify the improvement on known troublesome inputs

## Testing
- poetry run pytest
- poetry run ruff check .
- poetry run black src tests notebooks
- poetry run mypy src tests

------
https://chatgpt.com/codex/tasks/task_e_68ccbde51ac08323af9f2216e0a0c668