### PR TITLE
Add bidirectional CPED approximation

### DIFF
--- a/src/repmetric/api.py
+++ b/src/repmetric/api.py
@@ -11,7 +11,9 @@ from .backend import (
     _calculate_cped_cpp,
     _calculate_cped_distance_matrix_cpp,
     _calculate_cped_distance_matrix_py,
+    _calculate_cped_distance_matrix_py_bidirectional,
     _calculate_cped_py,
+    _calculate_cped_py_bidirectional,
     _calculate_levd_cpp,
     _calculate_levd_distance_matrix_cpp,
     _calculate_levd_distance_matrix_py,
@@ -19,25 +21,47 @@ from .backend import (
 )
 
 Backend = Literal["cpp", "c++", "python"]
-DistanceType = Literal["cped", "levd"]
+DistanceType = Literal[
+    "cped",
+    "levd",
+    "cped-bidir",
+    "cped_bidirectional",
+    "cped-bidirectional",
+]
+
+_CPED_BIDIRECTIONAL_TYPES = {
+    "cped-bidir",
+    "cped_bidirectional",
+    "cped-bidirectional",
+}
 
 
 def cped(X: str, Y: str, backend: Backend = "cpp") -> int:
     """Calculate the Copy & Paste Edit Distance (CPED)."""
-    use_cpp = backend in ("cpp", "c++") and CPP_AVAILABLE
-    if use_cpp:
-        return _calculate_cped_cpp(X, Y)
-    return _calculate_cped_py(X, Y)
+
+    backend_lower = backend.lower()
+    if backend_lower in ("cpp", "c++"):
+        if CPP_AVAILABLE:
+            return _calculate_cped_cpp(X, Y)
+        return _calculate_cped_py(X, Y)
+    if backend_lower == "python":
+        return _calculate_cped_py(X, Y)
+    raise ValueError(f"Unknown backend: {backend}")
 
 
 def cped_matrix(
     sequences: List[str], backend: Backend = "cpp", parallel: bool = True
 ) -> np.ndarray:
     """Calculate the pairwise CPED matrix."""
-    use_cpp = backend in ("cpp", "c++") and CPP_AVAILABLE
-    if use_cpp:
-        return _calculate_cped_distance_matrix_cpp(sequences, parallel=parallel)
-    return _calculate_cped_distance_matrix_py(sequences)
+
+    backend_lower = backend.lower()
+    if backend_lower in ("cpp", "c++"):
+        if CPP_AVAILABLE:
+            return _calculate_cped_distance_matrix_cpp(sequences, parallel=parallel)
+        return _calculate_cped_distance_matrix_py(sequences)
+    if backend_lower == "python":
+        return _calculate_cped_distance_matrix_py(sequences)
+    raise ValueError(f"Unknown backend: {backend}")
 
 
 def levd(s1: str, s2: str, backend: Backend = "cpp") -> int:
@@ -92,8 +116,10 @@ def edit_distance(
     Args:
         a: The first string or a list of strings.
         b: The second string. If 'a' is a list, this should be None.
-        distance_type: The type of distance to calculate ('cped' or 'levd').
-        backend: The backend to use for calculation ('cpp' or 'python').
+        distance_type: The type of distance to calculate.
+            Supported values are 'cped', 'levd', and the bidirectional CPED
+            aliases 'cped-bidir', 'cped_bidirectional', and 'cped-bidirectional'.
+        backend: The backend to use for calculation ('cpp', 'python').
         parallel: Whether to use parallel computation for the distance matrix.
 
     Returns:
@@ -102,19 +128,31 @@ def edit_distance(
     if isinstance(a, list):
         if b is not None:
             raise ValueError("When 'a' is a list, 'b' must be None.")
-        if distance_type == "cped":
+        distance_type_lower = distance_type.lower()
+        if distance_type_lower == "cped":
             return cped_matrix(a, backend=backend, parallel=parallel)
-        elif distance_type == "levd":
+        if distance_type_lower in _CPED_BIDIRECTIONAL_TYPES:
+            if backend.lower() != "python":
+                raise ValueError(
+                    "Bidirectional CPED is only available with the Python backend."
+                )
+            return _calculate_cped_distance_matrix_py_bidirectional(a)
+        if distance_type_lower == "levd":
             return levd_matrix(a, backend=backend, parallel=parallel)
-        else:
-            raise ValueError(f"Unknown distance_type: {distance_type}")
+        raise ValueError(f"Unknown distance_type: {distance_type}")
     elif isinstance(a, str) and isinstance(b, str):
-        if distance_type == "cped":
+        distance_type_lower = distance_type.lower()
+        if distance_type_lower == "cped":
             return cped(a, b, backend=backend)
-        elif distance_type == "levd":
+        if distance_type_lower in _CPED_BIDIRECTIONAL_TYPES:
+            if backend.lower() != "python":
+                raise ValueError(
+                    "Bidirectional CPED is only available with the Python backend."
+                )
+            return _calculate_cped_py_bidirectional(a, b)
+        if distance_type_lower == "levd":
             return levd(a, b, backend=backend)
-        else:
-            raise ValueError(f"Unknown distance_type: {distance_type}")
+        raise ValueError(f"Unknown distance_type: {distance_type}")
     else:
         raise TypeError(
             "Inputs 'a' and 'b' must be both strings or 'a' must be a list and 'b' None."

--- a/tests/test_repmetric.py
+++ b/tests/test_repmetric.py
@@ -49,6 +49,17 @@ def test_cped_matrix_correctness(backend):
     np.testing.assert_array_equal(dist_matrix, expected_matrix)
 
 
+def test_cped_bidirectional_improvement():
+    baseline = repmetric.edit_distance(
+        "", "aaaba", distance_type="cped", backend="python"
+    )
+    improved = repmetric.edit_distance(
+        "", "aaaba", distance_type="cped-bidir", backend="python"
+    )
+    assert baseline >= improved
+    assert improved == 4
+
+
 # --- Levenshtein Backend Correctness Tests ---
 
 
@@ -121,6 +132,12 @@ def test_edit_distance_matrix():
         repmetric.edit_distance(sequences, distance_type="cped", backend="python"),
         expected_cped,
     )
+    np.testing.assert_array_equal(
+        repmetric.edit_distance(
+            sequences, distance_type="cped-bidir", backend="python"
+        ),
+        expected_cped,
+    )
 
 
 def test_edit_distance_invalid_args():
@@ -130,6 +147,26 @@ def test_edit_distance_invalid_args():
         repmetric.edit_distance(["a"], "b")
     with pytest.raises(TypeError):
         repmetric.edit_distance("a")  # Missing b
+
+
+@pytest.mark.parametrize(
+    "distance_type",
+    ["cped-bidir", "cped_bidirectional", "cped-bidirectional"],
+)
+def test_edit_distance_cped_bidirectional_aliases(distance_type):
+    assert (
+        repmetric.edit_distance(
+            "", "aaaba", distance_type=distance_type, backend="python"
+        )
+        == 4
+    )
+
+
+def test_edit_distance_cped_bidirectional_requires_python_backend():
+    with pytest.raises(ValueError):
+        repmetric.edit_distance("a", "b", distance_type="cped-bidir", backend="cpp")
+    with pytest.raises(ValueError):
+        repmetric.edit_distance(["a", "b"], distance_type="cped-bidir", backend="cpp")
 
 
 # --- Fallback Mechanism Tests ---


### PR DESCRIPTION
## Summary
- add a reusable CPED DP table helper and a bidirectional refinement to reduce order-dependence
- route bidirectional CPED selection through `edit_distance` distance types while keeping the backend flag focused on Python vs. C++
- expand the test suite to cover the new distance-type aliases and backend validation

## Testing
- poetry run pytest
- poetry run ruff check .
- poetry run black src tests notebooks
- poetry run mypy src tests

------
https://chatgpt.com/codex/tasks/task_e_68ccbde51ac08323af9f2216e0a0c668