### PR TITLE
Add fallback matrix coverage tests

### DIFF
--- a/tests/test_repmetric.py
+++ b/tests/test_repmetric.py
@@ -245,6 +245,20 @@ def test_fallback_to_python():
         mock_levd_py.assert_called_once_with("x", "y")
         assert result == 456
 
+    with patch("repmetric.api._calculate_cped_distance_matrix_py") as mock_cped_matrix_py:
+        mock_cped_matrix_py.return_value = np.array([[0, 2], [1, 0]])
+        sequences = ["foo", "bar"]
+        result = repmetric.cped_matrix(sequences, backend="cpp")
+        mock_cped_matrix_py.assert_called_once_with(sequences)
+        np.testing.assert_array_equal(result, mock_cped_matrix_py.return_value)
+
+    with patch("repmetric.api._calculate_levd_distance_matrix_py") as mock_levd_matrix_py:
+        mock_levd_matrix_py.return_value = np.array([[0, 3], [3, 0]])
+        sequences = ["alpha", "beta"]
+        result = repmetric.levd_matrix(sequences, backend="cpp")
+        mock_levd_matrix_py.assert_called_once_with(sequences)
+        np.testing.assert_array_equal(result, mock_levd_matrix_py.return_value)
+
 
 # --- Axiom/Property Tests ---
 

--- a/tests/test_repmetric.py
+++ b/tests/test_repmetric.py
@@ -245,14 +245,18 @@ def test_fallback_to_python():
         mock_levd_py.assert_called_once_with("x", "y")
         assert result == 456
 
-    with patch("repmetric.api._calculate_cped_distance_matrix_py") as mock_cped_matrix_py:
+    with patch(
+        "repmetric.api._calculate_cped_distance_matrix_py"
+    ) as mock_cped_matrix_py:
         mock_cped_matrix_py.return_value = np.array([[0, 2], [1, 0]])
         sequences = ["foo", "bar"]
         result = repmetric.cped_matrix(sequences, backend="cpp")
         mock_cped_matrix_py.assert_called_once_with(sequences)
         np.testing.assert_array_equal(result, mock_cped_matrix_py.return_value)
 
-    with patch("repmetric.api._calculate_levd_distance_matrix_py") as mock_levd_matrix_py:
+    with patch(
+        "repmetric.api._calculate_levd_distance_matrix_py"
+    ) as mock_levd_matrix_py:
         mock_levd_matrix_py.return_value = np.array([[0, 3], [3, 0]])
         sequences = ["alpha", "beta"]
         result = repmetric.levd_matrix(sequences, backend="cpp")


### PR DESCRIPTION
## Summary
- extend the fallback test to assert the CPED and Levenshtein matrix helpers are used when the C++ backend is unavailable

## Testing
- poetry run pytest tests/test_repmetric.py::test_fallback_to_python

------
https://chatgpt.com/codex/tasks/task_e_68ce0099dc708323b34f80b89c6eb87c